### PR TITLE
Add deb822 for Ubuntu >= 24.04 and Debian >= 13

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,15 +25,46 @@
   when:
     - ansible_pkg_mgr in [ "apt" ]
   block:
-    - name: Add apt key
-      ansible.builtin.apt_key:
-        url: "{{ tailscale_apt_key_url }}"
-        keyring: /usr/share/keyrings/tailscale-archive-keyring.gpg
+    - name: Add tailscale repository | sources.list
+      when:
+        - (ansible_distribution == "Debian" and ansible_distribution_version is version('13', '<'))
+          or
+          (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('24.04', '<'))
+      block:
+        - name: Add apt key | sources.list
+          ansible.builtin.apt_key:
+            url: "{{ tailscale_apt_key_url }}"
+            keyring: /usr/share/keyrings/tailscale-archive-keyring.gpg
 
-    - name: Add the Tailscale repository (apt)
-      ansible.builtin.apt_repository:
-        repo: "{{ tailscale_apt_repo }}"
-        filename: tailscale
+        - name: Add the Tailscale repository (apt) | sources.list
+          ansible.builtin.apt_repository:
+            repo: "{{ tailscale_apt_repo }}"
+            filename: tailscale
+          register: _deb_repository
+
+    - name: Add tailscale repository | deb822
+      when:
+        - (ansible_distribution == "Debian" and ansible_distribution_version is version('13', '>='))
+          or
+          (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('24.04', '>='))
+      block:
+        - name: Add the Tailscale repository (apt) | deb822
+          ansible.builtin.deb822_repository:
+            name: tailscale
+            types: deb
+            uris: "{{ tailscale_apt_deb822_uri }}"
+            suites: '{{ ansible_distribution_release }}'
+            signed_by: "{{ tailscale_apt_key_url }}"
+            components:
+              - main
+            state: present
+          register: _deb_repository
+
+    - name: Update apt cache  # noqa: no-handler
+      ansible.builtin.apt:
+        update_cache: true
+      when:
+        - _deb_repository.changed
 
 - name: Run zypper tasks
   when:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,6 +7,7 @@ _tailscale_dependencies:
     - yum-utils
   Debian:
     - ca-certificates
+    - python3-debian
   Suse:
     - python3-rpm
 tailscale_dependencies: "{{ _tailscale_dependencies[ansible_os_family] | default(_tailscale_dependencies['default']) }}"
@@ -29,6 +30,7 @@ tailscale_repo_gpgkey: "{{ _tailscale_repo_gpgkey[ansible_distribution] }}"
 
 tailscale_apt_key_url: "https://pkgs.tailscale.com/stable/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}.noarmor.gpg"
 tailscale_apt_repo: "deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg] https://pkgs.tailscale.com/stable/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main"
+tailscale_apt_deb822_uri: "https://pkgs.tailscale.com/stable/{{ ansible_distribution | lower }}"
 
 _tailscale_sysclt_file:
   false: /etc/sysctl.conf


### PR DESCRIPTION
Use deb822 APT sources because this is the new default. In addition, apt-key is removed in Debian 13.

---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
see commit message

**Testing**
Ran molecule tests again Debian 12/13, Ubuntu 22.04/24.04
